### PR TITLE
Chore: Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - --branch=production
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.0
+    rev: v0.19.1
     hooks:
       - id: gitlint
 
@@ -38,7 +38,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: yamllint
         types: [yaml]


### PR DESCRIPTION
* github.com/jorisroovers/gitlint: v0.19.0 -> v0.19.1
* github.com/adrienverge/yamllint: v1.29.0 -> v1.30.0

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
