### PR TITLE
Chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: efd8b1e16f05132acf6edcf2827eeab21e0e00db # frozen: v3.0.0
+    rev: 672abe14d309fc28817d45b6be25ea976a92222a # frozen: v3.0.2
     hooks:
       - id: prettier
         stages: [commit]


### PR DESCRIPTION
github.com/pre-commit/mirrors-prettier: v3.0.0 -> v3.0.2 (frozen)

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
