### PR TITLE
Chore: Upgrade pre-commit hooks (frozen)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # frozen: v4.4.0
+    rev: c4a0b883114b00d8d76b479c820ce7950211c99b # frozen: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files
@@ -32,18 +32,18 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 672abe14d309fc28817d45b6be25ea976a92222a # frozen: v3.0.2
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         stages: [commit]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: b05e028c5881819161d11cb543fd96a30c06cceb # frozen: v1.32.0
+    rev: dd99a1c965b56027e9773442f41d3c58cc53c690 # frozen: v1.34.0
     hooks:
       - id: yamllint
         types: [yaml]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: 375289a39f5708101b1f916eb729e8d6da96993f # frozen: v0.9.0.5
+    rev: 4de1378e4cd853bfc2b111b05fff35e2dbf809a3 # frozen: v0.9.0.6
     hooks:
       - id: shellcheck


### PR DESCRIPTION
github.com/pre-commit/pre-commit-hooks: v4.4.0 -> v4.5.0 (frozen)
github.com/pre-commit/mirrors-prettier: v3.0.2 -> v4.0.0-alpha.8 (frozen)
github.com/adrienverge/yamllint.git: v1.32.0 -> v1.34.0 (frozen)
github.com/shellcheck-py/shellcheck-py: v0.9.0.5 -> v0.9.0.6 (frozen)

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
