### PR TITLE
Chore: Update shimataro/ssh-key-action to v2.7.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: Install SSH Key
-      uses: shimataro/ssh-key-action@38b53cb2f445ea2e0eb8872407e366677c41dbc6 # v2.6.1
+      uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 # v2.7.0
       with:
         key: ${{ inputs.key }}
         name: ${{ inputs.key_name }}


### PR DESCRIPTION
The workflows downstream throws the deprication warning:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20:

shimataro/ssh-key-action@38b53cb2f445ea2e0eb8872407e366677c41dbc6. For more information see: https://github.blog/changelog/2023-09-22 -github-actions-transitioning-from-node-16-to-node-20/.