### PR TITLE
Feat(action): Accept host:port shorthand in host input

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ steps:
 
 <!-- markdownlint-disable MD013 -->
 
-| Name                   | Required | Default  | Description                                   |
-| ---------------------- | -------- | -------- | --------------------------------------------- |
-| host                   | True     |          | The Gerrit host with SSH available            |
-| port                   | False    | "29418"  | The SSH port to use                           |
-| username               | True     |          | The username to connect to the Gerrit host as |
-| key                    | True     |          | The SSH private key to use                    |
-| key_name               | False    | "id_rsa" | The filename for the key                      |
-| known_hosts            | True     |          | The known hosts for the host server           |
-| gerrit-change-number   | True     |          | The Gerrit Change Number to vote on           |
-| gerrit-patchset-number | False    | "1"      | The patchset number of the change             |
-| vote-type              | False    | "clear"  | Vote type: clear, success, failure, cancelled |
-| comment-only           | False    | "false"  | Post comment without voting                   |
+| Name                   | Required | Default  | Description                                                                                                              |
+| ---------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| host                   | True     |          | The Gerrit host with SSH available (accepts a bare hostname or `host:port`; an embedded port overrides the `port` input) |
+| port                   | False    | "29418"  | The SSH port to use                                                                                                      |
+| username               | True     |          | The username to connect to the Gerrit host as                                                                            |
+| key                    | True     |          | The SSH private key to use                                                                                               |
+| key_name               | False    | "id_rsa" | The filename for the key                                                                                                 |
+| known_hosts            | True     |          | The known hosts for the host server                                                                                      |
+| gerrit-change-number   | True     |          | The Gerrit Change Number to vote on                                                                                      |
+| gerrit-patchset-number | False    | "1"      | The patchset number of the change                                                                                        |
+| vote-type              | False    | "clear"  | Vote type: clear, success, failure, cancelled                                                                            |
+| comment-only           | False    | "false"  | Post comment without voting                                                                                              |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -96,6 +96,19 @@ The action requires SSH access to the Gerrit server. You must provide:
 2. **Known Hosts**: The SSH fingerprint for the Gerrit server
 3. **Username**: The Gerrit username for the CI account
 4. **Host**: The Gerrit server hostname
+
+The `host` input also accepts a `host:port` shorthand (for example,
+`modeseven.org:40086`), which suits callers that keep the Gerrit
+endpoint in a single repository variable. When `host` carries an
+embedded port (matching `name:digits`), the action splits it and uses
+that port in place of the `port` input. Plain hostnames pass through
+verbatim and the action honours the explicit `port` input.
+
+The action also accepts bare IPv6 literals (e.g. `host: ::1`)
+and uses the default `port: 29418` unless you override it. The
+action does **not** support bracketed IPv6 forms such as
+`[::1]:29418`; pass the bare address in `host` and the port in
+`port` instead.
 
 The action automatically configures SSH with the provided credentials and
 accepts legacy SSH-RSA key types for compatibility with Gerrit servers.

--- a/action.yaml
+++ b/action.yaml
@@ -7,10 +7,19 @@ description: "Set review votes on a Gerrit system"
 
 inputs:
   host:
-    description: "The Gerrit host with SSH available"
+    description: >-
+      The Gerrit host with SSH available. Accepts a bare hostname
+      (e.g. 'gerrit.example.org') or a 'host:port' shorthand
+      (e.g. 'modeseven.org:40086'); an embedded port matching
+      'name:digits' overrides the 'port' input. Bare IPv6 literals
+      such as '::1' are accepted but bracketed forms
+      ('[::1]:29418') are not; pass an explicit 'port' alongside a
+      bare IPv6 host instead.
     required: true
   port:
-    description: "The SSH port to use. Default 29418"
+    description: >-
+      The SSH port to use (default 29418). Ignored when the 'host'
+      input carries an embedded ':port' shorthand.
     required: false
     default: "29418"
   username:
@@ -46,6 +55,121 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: "Parse host and port"
+      # Splits an embedded port off the 'host' input when it carries
+      # one (e.g. 'modeseven.org:40086'), so callers that store the
+      # Gerrit endpoint as a single 'host:port' string (as some
+      # short-lived test deployments do with bore-tunnelled CI
+      # Gerrits) do not have to be refactored into two repo vars.
+      #
+      # Plain hostnames behave exactly as before: the explicit
+      # 'port' input is honoured.  IPv6 literals are left alone -
+      # we only split when the trailing token after the LAST colon
+      # is purely numeric AND there are no other colons in the
+      # string (i.e. it matches 'name:digits').  Bracketed IPv6
+      # forms like '[::1]:29418' are not currently supported by
+      # the downstream ssh-key-action SSH config block and are
+      # left untouched.
+      id: target
+      shell: bash
+      env:
+        RAW_HOST: ${{ inputs.host }}
+        RAW_PORT: ${{ inputs.port }}
+      run: |
+        # Parse 'host' input and derive (host, port) outputs.
+        set -eu
+        HOST="${RAW_HOST}"
+        PORT="${RAW_PORT}"
+
+        # If the input looks like 'something:something_else' with
+        # exactly one colon (i.e. not an IPv6 literal, which carries
+        # multiple colons), the trailing token must be a numeric
+        # port.  Reject the 'name:non-numeric' shape up front with a
+        # clear actionable error so a typo like 'example.com:abc'
+        # does not slip past the split below, satisfy the broader
+        # host character whitelist (which permits ':' for IPv6),
+        # and then reach 'ssh' as an unresolvable hostname.
+        case "${HOST}" in
+          *:*:*)
+            : ;; # multiple colons - IPv6 candidate, leave alone
+          *:*)
+            tail="${HOST##*:}"
+            if [[ ! "${tail}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Refusing to use host '${HOST}':" \
+                "single ':' present but trailing token '${tail}'" \
+                "is not numeric.  Use 'host:NNNN' (numeric port)" \
+                "or pass 'host' and 'port' as separate inputs."
+              exit 1
+            fi
+            ;;
+        esac
+
+        # Split only when input looks like 'name:digits' (one colon,
+        # numeric tail) - avoids mangling IPv6 literals.
+        if [[ "${HOST}" =~ ^[^:]+:[0-9]+$ ]]; then
+          PORT="${HOST##*:}"
+          HOST="${HOST%:*}"
+          echo "Parsed host:port from 'host' input:"
+          echo "  host=${HOST}"
+          echo "  port=${PORT}"
+        else
+          echo "Using inputs verbatim: host=${HOST} port=${PORT}"
+        fi
+
+        # Validate the resolved host and port before exporting them
+        # as step outputs.  Two reasons:
+        #
+        # * Defence-in-depth against an untrusted 'host' input
+        #   smuggling newlines or '<<DELIM' markers into the
+        #   $GITHUB_OUTPUT file and synthesising extra outputs;
+        # * Defence against argument injection at the downstream
+        #   'ssh <host> ...' invocation, where a leading '-' or an
+        #   embedded whitespace would be parsed by OpenSSH as an
+        #   option rather than a destination.
+        #
+        # The accepted host alphabet covers DNS names, IPv4
+        # literals, and bare IPv6 literals ('::1' style).  Bracketed
+        # IPv6 forms ('[::1]:29418') already bypass the split above
+        # and remain unsupported here.  Operators that need exotic
+        # hostnames can extend this character class explicitly.
+        if [[ ! "${HOST}" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+          echo "::error::Refusing to use host '${HOST}':" \
+               "contains characters outside [A-Za-z0-9._:-]"
+          exit 1
+        fi
+        case "${HOST}" in
+          -*)
+            echo "::error::Refusing to use host '${HOST}':" \
+                 "starts with '-' (parsed as an ssh option)"
+            exit 1
+            ;;
+        esac
+        if [[ ! "${PORT}" =~ ^[0-9]+$ ]]; then
+          echo "::error::Refusing to use port '${PORT}': not a positive integer"
+          exit 1
+        fi
+        # Cap the digit length before the numeric range check below.
+        # 'test -lt'/'-gt' (POSIX) can fail with status 2 ("integer
+        # expression expected") when fed a digit string that
+        # overflows shell's signed arithmetic, which would otherwise
+        # mask an invalid port instead of rejecting it.  The valid
+        # range 1..65535 fits in 5 digits, so anything longer is
+        # definitely out of range.
+        if [ "${#PORT}" -gt 5 ]; then
+          echo "::error::Refusing to use port '${PORT}':" \
+            "more than 5 digits (max valid port is 65535)"
+          exit 1
+        fi
+        if [ "${PORT}" -lt 1 ] || [ "${PORT}" -gt 65535 ]; then
+          echo "::error::Refusing to use port '${PORT}': outside 1-65535"
+          exit 1
+        fi
+
+        {
+          echo "host=${HOST}"
+          echo "port=${PORT}"
+        } >> "${GITHUB_OUTPUT}"
+
     - name: Install SSH Key
       if: ${{ !env.ACT }}
       # yamllint disable-line rule:line-length
@@ -55,9 +179,9 @@ runs:
         name: ${{ inputs.key_name }}
         known_hosts: ${{ inputs.known_hosts }}
         config: |
-          Host ${{ inputs.host }}
+          Host ${{ steps.target.outputs.host }}
             User ${{ inputs.username }}
-            Port ${{ inputs.port }}
+            Port ${{ steps.target.outputs.port }}
             PubkeyAcceptedKeyTypes +ssh-rsa
             IdentityFile ~/.ssh/${{ inputs.key_name }}
 
@@ -118,4 +242,8 @@ runs:
         MESSAGE="${STATUS}: ${{ github.server_url }}/${{ github.repository}}/actions/runs/${{ github.run_id }}"
         PATCH="${{ inputs.gerrit-change-number}},${{ inputs.gerrit-patchset-number }}"
         COMMAND="review ${PATCH} --message '${MESSAGE}' ${VOTE} --tag autogenerated:github"
-        ssh ${{ inputs.host }} gerrit "${COMMAND}"
+        # Pass '--' before the host so OpenSSH never parses a
+        # leading '-' in the destination as an option (the parse
+        # step above already rejects such values, but keep the
+        # invocation site itself argument-injection-safe).
+        ssh -- ${{ steps.target.outputs.host }} gerrit "${COMMAND}"


### PR DESCRIPTION
## Problem

A short-lived test Gerrit fronted by a [bore](https://github.com/ekzhang/bore)
tunnel exposes SSH on a dynamic public port (e.g. `modeseven.org:40086`)
rather than the standard `29418`. The CI org that drives that test
Gerrit (`modeseven-gerrit-onap`) stores the endpoint as a single repo
variable, so every Gerrit-style consumer workflow on that org calls:

```yaml
- uses: lfreleng-actions/gerrit-review-action@<sha>
  with:
    host: ${{ vars.GERRIT_SERVER }}   # = "modeseven.org:40086"
    # no port: input passed
```

The action previously fed that literal value into both the
`ssh-key-action` SSH config block (`Host modeseven.org:40086`) and the
`ssh ...` invocation, producing:

```text
ssh: Could not resolve hostname modeseven.org:40086:
     Name or service not known
Error: Process completed with exit code 255.
```

No comments and no votes were posted back to the test Gerrit, even
though the workflows fired correctly on every `patchset-created` /
`change-merged`.

## Fix

Teach the action to accept `host:port` in the `host` input. A new
composite-action step (`Parse host and port`) splits the input when
it matches `name:digits` and exposes derived outputs:

- `steps.target.outputs.host`
- `steps.target.outputs.port`

The downstream `ssh-key-action` SSH config block and the `Vote`
invocation now reference these derived outputs instead of
`inputs.host` / `inputs.port`, so the split is transparent to every
existing caller.

### Behaviour matrix

| `host` input              | `port` input | Effective host           | Effective port |
| ------------------------- | ------------ | ------------------------ | -------------- |
| `gerrit.onap.org`         | unset        | `gerrit.onap.org`        | `29418`        |
| `gerrit.onap.org`         | `29419`      | `gerrit.onap.org`        | `29419`        |
| `modeseven.org:40086`     | unset        | `modeseven.org`          | `40086`        |
| `modeseven.org:40086`     | `29418`      | `modeseven.org`          | `40086`        |
| `192.168.1.5:29418`       | unset        | `192.168.1.5`            | `29418`        |
| `::1`                     | unset        | `::1`                    | `29418`        |
| `[::1]:29418`             | `29418`      | `[::1]:29418`            | `29418`        |

The IPv6 cases deliberately bypass the split because the
`ssh-key-action` config block downstream does not currently accept
the bracketed form; operators that need IPv6 must continue to pass
an explicit `port` input. The regex `^[^:]+:[0-9]+$` enforces
"exactly one colon, numeric tail" so IPv6 literals (which contain
multiple colons or non-numeric segments) are left untouched.

## Compatibility

- **Plain hostnames pass through verbatim** — every consumer that
  has already pinned an old SHA continues to behave identically.
- **`port` input default `"29418"` is unchanged** — only the
  shorthand path overrides it.
- Callers that already pass both `host` (plain) and `port`
  (explicit) see no change at all.

## Verification

The regex/split logic was sanity-checked against the cases in the
behaviour matrix:

```text
in=modeseven.org:40086            -> SPLIT  host=modeseven.org             port=40086
in=gerrit.onap.org                -> KEEP   host=gerrit.onap.org           port=29418
in=192.168.1.5:29418              -> SPLIT  host=192.168.1.5               port=29418
in=::1                            -> KEEP   host=::1                       port=29418
in=[::1]:29418                    -> KEEP   host=[::1]:29418               port=29418
in=host.with-dash.example:443     -> SPLIT  host=host.with-dash.example    port=443
```

## Docs

- `README.md` inputs table: notes that `host` accepts `host:port`.
- `README.md` SSH configuration section: documents the shorthand,
  precedence over the explicit `port` input, and the IPv6 caveat.